### PR TITLE
We need Bionic as a base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Otherwise we'll be missing libisl19 as it's not available on later versions.