### PR TITLE
add GitHub workflow to test HermitCore

### DIFF
--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -35,5 +35,5 @@ jobs:
       run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/thr_hello
     - name: Run hello++
       run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello++
-    - name: Run jacobi
-      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 1G -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi
+    #- name: Run jacobi
+    #  run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 1G -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: true
     - name: Install qemu
-      run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86
+      run: apt-get update --fix-missing && sudo apt-get install qemu-system-x86
     - name: Build apps
       run: |
         mkdir build

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -29,3 +29,11 @@ jobs:
       run: make
     - name: Run hello
       run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello
+    - name: Run hellof
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hellof
+    - name: Run thr_hello
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/thr_hello
+    - name: Run hello++
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello++
+    - name: Run jacobi
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -16,8 +16,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: List working directory
-      run: ls
+    - name: Check Cargo availability
+      run: cargo --version
+    - name: Install qemu
+      run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86
     - name: Build apps
       run: |
         mkdir build

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: true
     - name: Install qemu
-      run: apt-get update --fix-missing && sudo apt-get install qemu-system-x86
+      run: apt-get update --fix-missing && apt-get install qemu-system-x86
     - name: Build apps
       run: |
         mkdir build

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -24,3 +24,6 @@ jobs:
         cd build
         cmake ..
         make
+    - name: Build loader
+      working-directory: loader
+      make

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run hello++
       run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello++
     - name: Run jacobi
-      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 1G -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -27,3 +27,5 @@ jobs:
     - name: Build loader
       working-directory: loader
       run: make
+    - name: Run hello
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -14,7 +14,5 @@ jobs:
     container: ghcr.io/hermitcore/hermit-toolchain:latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          lfs: true
     - name: List working directory
       run: ls

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -1,0 +1,20 @@
+name: Test x86_64
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - staging
+      - trying
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/hermitcore/hermit-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          lfs: true
+    - name: List working directory
+      run: ls

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: true
     - name: Install qemu
-      run: apt-get update --fix-missing && apt-get install qemu-system-x86
+      run: apt-get update --fix-missing && apt-get install -y qemu-system-x86
     - name: Build apps
       run: |
         mkdir build

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -16,8 +16,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Check Cargo availability
-      run: cargo --version
     - name: Install qemu
       run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86
     - name: Build apps

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -16,3 +16,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: List working directory
       run: ls
+    - name: Build apps
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -14,6 +14,8 @@ jobs:
     container: ghcr.io/hermitcore/hermit-toolchain:latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: List working directory
       run: ls
     - name: Build apps

--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -26,4 +26,4 @@ jobs:
         make
     - name: Build loader
       working-directory: loader
-      make
+      run: make

--- a/README.md
+++ b/README.md
@@ -26,19 +26,21 @@ the HermitCore-rs kernel and applications you need:
  * Recent host compiler such as GCC
  * HermitCore cross-toolchain, i.e. Binutils, GCC, newlib, pthreads
  * [Rust compiler (nightly release)](https://www.rust-lang.org/en-US/install.html)
- * [cargo-xbuild](https://github.com/rust-osdev/cargo-xbuild), which can be installed with `cargo install cargo-xbuild`
  * Rust source code for cross-compiling, which can be installed with `rustup component add rust-src`.
 
 ### HermitCore-rs cross-toolchain
 
-We provide prebuilt packages (currently Ubuntu 18.04 only) of the HermitCore-rs
-toolchain. The packages can be installed as follows:
+We provide a Docker container with all required tools to build HermitCore-rs applications.
+
+To test the toolchain, create a simple C program (e.g. `hello world`) and name the file `main.c`.
+Use following command to build the applications:
 
 ```bash
-$ echo "deb [trusted=yes] https://dl.bintray.com/hermitcore/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
-$ sudo apt-get -qq update
-$ sudo apt-get install binutils-hermit newlib-hermit-rs pte-hermit-rs gcc-hermit-rs libomp-hermit-rs
+$ docker run -v $PWD:/volume -w /volume --rm -t ghcr.io/hermitcore/hermit-toolchain:latest x86_64-hermit-gcc -o main main.c
 ```
+
+The command mounts the current directory as working directory into a docker container and runs the cross-compiler to build the application.
+Afterwards, you will find the executable `main` in your current directory.
 
 If you want to build the toolchain yourself, have a look at the `path2rs` branch of the repository
 [hermit-toolchain](https://github.com/hermitcore/hermit-toolchain).


### PR DESCRIPTION
The tests base on Docker container, which already includes the HermitCore's cross-toolchain. This tests runs in the container, build all examples and run the test application in a virtual machine. 