### PR TITLE
Delete bors.toml

### DIFF
--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -2,11 +2,7 @@ name: Test x86_64
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
-      - staging
-      - trying
+  merge_group:
 
 jobs:
   build:

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = [
-  "build",
-  "ci/gitlab/staging",
-]
-delete_merged_branches = true
-timeout_sec = 7200


### PR DESCRIPTION
bors-ng is now [deprecated]. We should migrate to [built-in merge queues].

[deprecated]: https://bors.tech/newsletter/2023/05/01/tmib-76/
[built-in merge queues]: https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/