### PR TITLE
Bump version of loader

### DIFF
--- a/.github/workflows/x86_64.yml
+++ b/.github/workflows/x86_64.yml
@@ -22,19 +22,19 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: hermit-os/loader
-        version: tags/v0.4.3
-        file: rusty-loader-x86_64
+        version: tags/v0.5.0
+        file: hermit-loader-x86_64
     - name: Install QEMU
       run: |
         apt-get update
         apt-get -y install qemu-system-x86
     - name: Run hello
-      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel rusty-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel hermit-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello
     #- name: Run hellof
-    #  run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel rusty-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hellof
+    #  run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel hermit-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hellof
     - name: Run thr_hello
-      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel rusty-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/thr_hello
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel hermit-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/thr_hello
     - name: Run hello++
-      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel rusty-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello++
+      run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 128M -serial stdio -kernel hermit-loader-x86_64 -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/hello++
     #- name: Run jacobi
     #  run: qemu-system-x86_64 -smp 1 -cpu qemu64,apic,fsgsbase,rdtscp,xsave,xsaveopt,fxsr,rdrand -display none -m 1G -serial stdio -kernel rusty-loader -initrd build/local_prefix/opt/hermit/x86_64-hermit/extra/tests/jacobi


### PR DESCRIPTION
I believe this is why the CI run is failing now, because the kernel was updated without also changing the loader.